### PR TITLE
Update Supervisely SDK to 6.73.564

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM supervisely/base-py-sdk:6.73.483
+FROM supervisely/base-py-sdk:6.73.564
 
 WORKDIR /app
 

--- a/config.json
+++ b/config.json
@@ -3,7 +3,7 @@
 	"version": "2.0.0",
 	"name": "Figures Validator",
 	"description": "Service for validating figures geometry",
-	"docker_image": "supervisely/base-py-sdk:6.73.309",
+	"docker_image": "supervisely/base-py-sdk:6.73.564",
 	"categories": ["images"],
 	"icon": "",
 	"icon_cover": true,

--- a/config.json
+++ b/config.json
@@ -14,5 +14,5 @@
 	"context_menu": {
 		"target": ["images_project", "ecosystem"]
 	},
-	"instance_version": "6.12.28"
+	"instance_version": "6.15.60"
 }

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,4 @@
-supervisely==6.73.483
+supervisely==6.73.564
 
 # code formatter
 black


### PR DESCRIPTION
Updates default Supervisely Docker apps to Supervisely SDK `6.73.564`.

- Updates `docker_image` tags for default Supervisely images.
- Updates Supervisely SDK references in requirements and Dockerfiles.
- Does not release applications.

Validation: generated ecosystem inventory report.
